### PR TITLE
UI design refresh, Swagger cleanup, and CSP/font fixes

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,10 +1,10 @@
-# Installation Guide - Pure Node.js Version
+# Installation Guide
 
 This guide will help you set up the File Conversion Utility using only Node.js libraries - no external software dependencies required.
 
-## Enterprise-Friendly Approach
+## Approach
 
-This version is specifically designed for enterprise environments where installing external software like LibreOffice, FFmpeg, or ImageMagick is not permitted due to security policies.
+This project avoids external software like LibreOffice, FFmpeg, or ImageMagick. It relies on Node.js libraries only.
 
 ## Prerequisites
 
@@ -154,26 +154,25 @@ The remaining warnings are deprecation notices in transitive dependencies:
 
 ## Key Benefits
 
-### 🔒 Security & Compliance
+### Security & Compliance
 
 - **No external software dependencies**
 - **No system-level installations required**
 - **Sandboxed execution environment**
 - **Audit-friendly pure JavaScript**
 
-### 🚀 Deployment Advantages
+### Deployment Advantages
 
 - **Docker-friendly** (smaller images)
 - **Cloud-native** (works in any Node.js environment)
 - **Scalable** (no external process dependencies)
 - **Cross-platform** (consistent behavior everywhere)
 
-### 💼 Enterprise Ready
+### Operational Notes
 
-- **IT department approved** (no security concerns)
-- **Easy CI/CD integration**
-- **Containerization friendly**
-- **Microservices compatible**
+- Easy CI/CD integration
+- Containerization friendly
+- Microservices compatible
 
 ## Verification
 
@@ -223,9 +222,10 @@ The remaining warnings are deprecation notices in transitive dependencies:
 - **pdf-lib & pdf-parse**: PDF manipulation and text extraction
 - **docx**: DOCX document creation and parsing
 - **mammoth**: DOCX to HTML conversion
-- **xlsx**: Excel file processing
+- **exceljs**: Excel file processing
+- **html-to-docx**: HTML to DOCX conversion
+- **extract-zip & jszip**: ZIP extraction and metadata
 - **lamejs**: MP3 encoding
-- **jszip**: ZIP file handling
 
 ### Why These Libraries?
 
@@ -345,13 +345,12 @@ NODE_ENV=production
 
 ## Support
 
-This pure Node.js approach provides:
+This approach provides:
 
-- ✅ **Enterprise security compliance**
-- ✅ **Easy deployment and scaling**
-- ✅ **No external dependencies**
-- ✅ **Consistent cross-platform behavior**
-- ✅ **Full document and image processing**
-- ⚠️ **Limited video/audio processing** (by design for security)
+- Easy deployment and scaling
+- No external dependencies
+- Consistent cross-platform behavior
+- Full document and image processing
+- Limited video/audio processing (by design)
 
-For advanced video/audio needs, integrate with cloud services or dedicated microservices while keeping the core application secure and dependency-free.
+For advanced video/audio needs, integrate with cloud services or dedicated microservices.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # File Conversion Utility
 
-A comprehensive enterprise-friendly Node.js file conversion utility with REST API and web interface. Built with pure Node.js libraries only - no external software dependencies required.
+A Node.js file conversion utility with a REST API and a simple web interface. Built with pure Node.js libraries only — no external software dependencies required.
 
 ## Supported Conversions
 
@@ -31,9 +31,9 @@ A comprehensive enterprise-friendly Node.js file conversion utility with REST AP
 - ZIP file extraction with detailed summary
 - Archive information and content listing
 
-## Enterprise-Ready Installation
+## Installation
 
-No external software required. This version uses only Node.js libraries for maximum compatibility and security.
+No external software required. This project uses only Node.js libraries.
 
 ### Prerequisites
 
@@ -66,28 +66,14 @@ npm audit --omit=dev
 
 Expected result: "found 0 vulnerabilities"
 
-## Key Benefits
-
-### Enterprise Security Friendly
+## Highlights
 
 - No external software dependencies
 - Pure Node.js libraries only
 - Sandboxed execution environment
-- IT department approved architecture
-
-### Easy Deployment
-
-- Docker-friendly with smaller container images
-- Cloud-native compatibility
-- Microservices ready architecture
+- Docker-friendly and cloud-compatible
 - Cross-platform consistency
-
-### Production Ready
-
-- High-quality document processing
-- Professional image conversion capabilities
 - Comprehensive error handling and logging
-- Scalable and maintainable architecture
 
 ## Usage
 
@@ -131,7 +117,10 @@ The application provides comprehensive API documentation using OpenAPI 3.0 stand
 - `GET /api-docs.json` - OpenAPI specification in JSON format
 - `GET /api-docs.yaml` - OpenAPI specification in YAML format
 
-Note: Updated to use modern dependencies without deprecated packages for clean installation.
+Notes:
+
+- No API key required; the Swagger "Authorize" button is removed.
+- Uses up-to-date dependencies to avoid deprecated packages.
 
 ### Available API Endpoints
 
@@ -170,11 +159,11 @@ LOG_LEVEL=info
 
 ## Security Features
 
-- Rate limiting to prevent API abuse
-- File type validation and security checks
+- Rate limiting
+- File type validation
 - Content Security Policy headers
-- CORS configuration for cross-origin requests
-- Comprehensive input validation
+- CORS configuration
+- Input validation
 - Secure file handling with automatic cleanup
 
 ## License

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -342,13 +342,4 @@ components:
         error: "Conversion failed"
         message: "Unable to process the uploaded file"
 
-  securitySchemes:
-    ApiKeyAuth:
-      type: apiKey
-      in: header
-      name: X-API-Key
-      description: API key for authentication (if implemented)
-# Global security (commented out as not implemented yet)
-# security:
-#   - ApiKeyAuth: []
-
+  # Note: No security schemes are defined because an API key is not required.

--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>File Conversion Utility</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap"
+      rel="stylesheet"
+    />
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
       rel="stylesheet"
@@ -80,6 +86,94 @@
         margin: 20px 0;
       }
     </style>
+    <style>
+      :root {
+        --mv-primary: #0072bc;
+        --mv-primary-dark: #005a96;
+        --mv-secondary: #00a651;
+        --mv-accent: #f6a800;
+        --mv-dark: #2c3e50;
+        --mv-muted: #6c757d;
+        --mv-bg: #f5f7f9;
+        --mv-surface: #ffffff;
+        --mv-border: #e1e6eb;
+      }
+
+      html,
+      body {
+        font-family: "Roboto", system-ui, -apple-system, Segoe UI, Roboto,
+          "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji",
+          "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+        color: var(--mv-dark);
+        background: var(--mv-bg);
+      }
+
+      a {
+        color: var(--mv-primary);
+      }
+      a:hover {
+        color: var(--mv-primary-dark);
+      }
+
+      .btn-primary {
+        background-color: var(--mv-primary);
+        border-color: var(--mv-primary);
+      }
+      .btn-primary:hover {
+        background-color: var(--mv-primary-dark);
+        border-color: var(--mv-primary-dark);
+      }
+      .btn-outline-primary {
+        color: var(--mv-primary);
+        border-color: var(--mv-primary);
+      }
+      .btn-outline-primary:hover {
+        background-color: var(--mv-primary);
+        color: #fff;
+      }
+
+      .alert-info {
+        background-color: #e8f4ff;
+        border-color: #cfe9ff;
+        color: #084298;
+      }
+
+      .drop-zone {
+        border-color: var(--mv-border);
+        background: var(--mv-surface);
+      }
+      .drop-zone:hover,
+      .drop-zone.dragover {
+        border-color: var(--mv-primary);
+        background: #e8f4ff;
+      }
+
+      .conversion-card {
+        border: 1px solid var(--mv-border);
+        background: var(--mv-surface);
+      }
+      .format-badge {
+        background: var(--mv-primary);
+      }
+
+      .hero-section {
+        background: linear-gradient(
+          135deg,
+          var(--mv-primary) 0%,
+          var(--mv-primary-dark) 100%
+        );
+        color: #fff;
+      }
+      .feature-icon {
+        color: var(--mv-secondary);
+      }
+      .supported-formats {
+        background: var(--mv-bg);
+      }
+      .text-muted {
+        color: var(--mv-muted) !important;
+      }
+    </style>
   </head>
   <body>
     <!-- Hero Section -->
@@ -87,14 +181,12 @@
       <div class="container">
         <div class="row">
           <div class="col-lg-8 mx-auto text-center">
-            <h1 class="display-4 fw-bold mb-4">
+            <h1 class="display-4 fw-bold mb-3">
               <i class="bi bi-arrow-left-right"></i>
               File Conversion Utility
             </h1>
-            <p class="lead mb-4">
-              Enterprise-friendly file conversion using
-              <strong>pure Node.js libraries only</strong>. No external software
-              dependencies required!
+            <p class="lead mb-0">
+              Upload a file, choose a format, download the result.
             </p>
           </div>
         </div>
@@ -245,17 +337,12 @@
       <div class="row mt-5">
         <div class="col-12">
           <div class="conversion-card">
-            <h4 class="mb-4">
+            <h4 class="mb-3">
               <i class="bi bi-code-slash"></i>
-              API Access
+              API
             </h4>
 
-            <p>Use our REST API for programmatic file conversions:</p>
-            <div class="alert alert-info">
-              <i class="bi bi-shield-check"></i>
-              <strong>Enterprise Ready:</strong> No external software
-              dependencies - uses pure Node.js libraries only!
-            </div>
+            <p class="mb-3">Use the REST API for programmatic conversions.</p>
 
             <div class="bg-light p-3 rounded">
               <code>
@@ -294,8 +381,8 @@
     <footer class="bg-light mt-5 py-4">
       <div class="container text-center">
         <p class="text-muted mb-0">
-          <i class="bi bi-shield-check"></i>
-          Enterprise-Friendly File Conversion - Pure Node.js Libraries Only
+          <i class="bi bi-arrow-left-right"></i>
+          File Conversion Utility
         </p>
       </div>
     </footer>

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -136,9 +136,20 @@ const config = {
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
-        styleSrc: ["'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net"],
+        styleSrc: [
+          "'self'",
+          "'unsafe-inline'",
+          "https://cdn.jsdelivr.net",
+          "https://fonts.googleapis.com",
+        ],
         scriptSrc: ["'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net"],
         imgSrc: ["'self'", "data:", "blob:", "https://validator.swagger.io"],
+        fontSrc: [
+          "'self'",
+          "data:",
+          "https://fonts.gstatic.com",
+          "https://cdn.jsdelivr.net",
+        ],
       },
     },
   },

--- a/src/config/swagger.js
+++ b/src/config/swagger.js
@@ -99,11 +99,20 @@ module.exports = {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>File Conversion API Documentation</title>
   <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.0.0/swagger-ui.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet" />
   <style>
+    :root { --mv-primary: #0072bc; --mv-primary-dark: #005a96; --mv-secondary: #00a651; --mv-dark: #2c3e50; --mv-bg: #f5f7f9; --mv-surface: #ffffff; --mv-border: #e1e6eb; }
+    html, body { font-family: 'Roboto', Arial, sans-serif; background: var(--mv-bg); }
     .swagger-ui .topbar { display: none; }
     .swagger-ui .info { margin: 20px 0; }
-    .swagger-ui .info .title { color: #2c3e50; }
-    .swagger-ui .scheme-container { background: #f8f9fa; padding: 10px; border-radius: 5px; }
+    .swagger-ui .info .title { color: var(--mv-dark); }
+    .swagger-ui .scheme-container { background: var(--mv-bg); padding: 10px; border-radius: 5px; }
+    .swagger-ui .btn.authorize, .swagger-ui .opblock .opblock-summary-method { background: var(--mv-primary); border-color: var(--mv-primary); }
+    .swagger-ui .opblock.opblock-post { border-color: var(--mv-primary); background: #e8f4ff; }
+    .swagger-ui .opblock .opblock-section-header { background: var(--mv-surface); }
+    .swagger-ui .tab li.active a { border-bottom-color: var(--mv-primary); color: var(--mv-primary); }
   </style>
 </head>
 <body>

--- a/src/server.js
+++ b/src/server.js
@@ -111,9 +111,14 @@ app.use(express.urlencoded({ extended: true, limit: config.uploadLimit }));
  * In local development, serve from public directory
  */
 if (!process.env.VERCEL) {
+  // Serve root directory assets (e.g., index.html, app.js) for local development
+  const rootPath = path.join(__dirname, "..");
+  app.use(express.static(rootPath));
+
+  // Also serve legacy public directory if it exists (fallback)
   const publicPath = path.join(__dirname, "../public");
   if (fs.existsSync(publicPath)) {
-    console.log("Static files served from:", publicPath);
+    console.log("Additional static files served from:", publicPath);
     app.use(express.static(publicPath));
   }
 }
@@ -136,9 +141,14 @@ app.use("/api", conversionRoutes);
  * Serves the primary HTML interface for file conversions
  */
 app.get("/", (req, res) => {
-  const indexPath = path.join(__dirname, "../public/index.html");
-  if (fs.existsSync(indexPath)) {
-    return res.sendFile(indexPath);
+  const indexRoot = path.join(__dirname, "../index.html");
+  const indexPublic = path.join(__dirname, "../public/index.html");
+
+  if (fs.existsSync(indexRoot)) {
+    return res.sendFile(indexRoot);
+  }
+  if (fs.existsSync(indexPublic)) {
+    return res.sendFile(indexPublic);
   }
   return res.redirect(302, "/api-docs");
 });


### PR DESCRIPTION
**Summary**:
  - Refreshes the frontend to align with the new design style (fonts, colors, layout nuances).
  - Simplifies on-page copy for internal utility use.
  - Removes Swagger’s API key “Authorize” button since no auth is required.
  - Fixes CSP to allow Google Fonts and bootstrap-icons fonts.
  - Ensures local dev serves the updated root `index.html` instead of a stale `public/index.html`.

**Changes**:
  - index.html: Roboto font, theme tokens, blue/green palette, concise hero/API/footer copy.
  - src/config/swagger.js: Re-themed Swagger UI; loads Roboto; no auth button needed.
  - docs/openapi.yaml: Removed `components.securitySchemes` and any global `security`.
  - src/config/config.js: CSP extended to include `fonts.googleapis.com`, `fonts.gstatic.com`, and `cdn.jsdelivr.net` for fonts.
  - src/server.js: In local dev, serve repo root first; fallback to `public/` if present. Root route tries `../index.html` then `../public/index.html`.

**How to test**:
  - npm start → visit /
    - Blue gradient banner; concise hero text: “Upload a file, choose a format, download the result.”
    - Upload a file, pick a format, convert, and download result.
  - Visit /api-docs
    - No “Authorize” button.
    - UI uses Roboto; colors match app theme.
  - Browser dev tools console
    - No CSP font errors for Google Fonts or bootstrap-icons.
  - If you saw the old purple banner, hard refresh (Ctrl+F5). Local server now prefers root `index.html`.
